### PR TITLE
feat: Dependency hash

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
   "dependencies": {
     "@logseq/libs": "0.0.6",
     "cheerio": "1.0.0-rc.11",
+    "hash-sum": "2.0.0",
     "highlight.js": "11.5.1",
     "lodash": "^4.17.21",
     "mldoc": "1.4.0",

--- a/src/SyncronizedLogseq.ts
+++ b/src/SyncronizedLogseq.ts
@@ -1,4 +1,4 @@
-import { BlockEntity, BlockIdentity, BlockUUID, EntityID, PageIdentity } from "@logseq/libs/dist/LSPlugin";
+import { BlockEntity, BlockIdentity, BlockUUID, EntityID, PageEntity, PageIdentity } from "@logseq/libs/dist/LSPlugin";
 import AwaitLock from "await-lock";
 import objectHash from "object-hash";
 /***
@@ -76,7 +76,7 @@ export namespace SyncronizedLogseq {
             return result;
         }
 
-        static async getPage(srcPage: PageIdentity | EntityID): Promise<PageIdentity | null> {
+        static async getPage(srcPage: PageIdentity | EntityID): Promise<PageEntity | null> {
             if (cache.has(objectHash({ operation: "getPage", parameters: { srcPage } })))
                 return cache.get(objectHash({ operation: "getPage", parameters: { srcPage } }));
             let page = null;

--- a/src/SyncronizedLogseq.ts
+++ b/src/SyncronizedLogseq.ts
@@ -1,45 +1,81 @@
 import { BlockEntity, BlockIdentity, EntityID, PageIdentity } from "@logseq/libs/dist/LSPlugin";
 import AwaitLock from "await-lock";
+import objectHash from "object-hash";
 /***
  * Syncronization-safe logseq api wrapper for the Logseq plugin.
  * This is needed to fix #58
  * */
 
+type LogSeqOperation = {
+    operation: String,
+    parameters: any
+}
+type LogSeqOperationHash = string;
+
+let cache = new Map<LogSeqOperationHash, any>();
+let cacheHit = 0;
+let originalCacheGet = cache.get.bind(cache);
+cache.get = function (key: LogSeqOperationHash) {
+    cacheHit++;
+    return originalCacheGet(key);
+}
 let getLogseqLock = new AwaitLock();
 export namespace SyncronizedLogseq {
     export class Editor {
         static async getBlock(srcBlock: BlockIdentity | EntityID, opts?: Partial<{ includeChildren: boolean; }>): Promise<BlockEntity | null> {
+            if (cache.has(objectHash({ operation: "getBlock", parameters: { srcBlock, opts } })))
+                return cache.get(objectHash({ operation: "getBlock", parameters: { srcBlock, opts } }));
             let block = null;
             await getLogseqLock.acquireAsync();
-            try {block = await logseq.Editor.getBlock(srcBlock, opts);}
-            catch(e) { console.error(e); }
+            try {
+                block = await logseq.Editor.getBlock(srcBlock, opts);
+                cache.set(objectHash({ operation: "getBlock", parameters: { srcBlock, opts } }), block);
+            }
+            catch (e) { console.error(e); }
             finally { getLogseqLock.release(); }
             return block;
         }
-    
+
         static async getPage(srcPage: PageIdentity | EntityID): Promise<PageIdentity | null> {
+            if (cache.has(objectHash({ operation: "getPage", parameters: { srcPage } })))
+                return cache.get(objectHash({ operation: "getPage", parameters: { srcPage } }));
             let page = null;
             await getLogseqLock.acquireAsync();
-            try {page = await logseq.Editor.getPage(srcPage);}
-            catch(e) { console.error(e); }
+            try {
+                page = await logseq.Editor.getPage(srcPage);
+                cache.set(objectHash({ operation: "getPage", parameters: { srcPage } }), page);
+            }
+            catch (e) { console.error(e); }
             finally { getLogseqLock.release(); }
             return page;
         }
-    
+
         static async getPageBlocksTree(srcPage: PageIdentity): Promise<Array<BlockEntity>> {
+            if (cache.has(objectHash({ operation: "getPageBlocksTree", parameters: { srcPage } })))
+                return cache.get(objectHash({ operation: "getPageBlocksTree", parameters: { srcPage } }));
             let pageBlockTree = null;
             await getLogseqLock.acquireAsync();
-            try {pageBlockTree = await logseq.Editor.getPageBlocksTree(srcPage);}
-            catch(e) { console.error(e); }
+            try {
+                pageBlockTree = await logseq.Editor.getPageBlocksTree(srcPage);
+                cache.set(objectHash({ operation: "getPageBlocksTree", parameters: { srcPage } }), pageBlockTree);
+            }
+            catch (e) { console.error(e); }
             finally { getLogseqLock.release(); }
             return pageBlockTree;
         }
-    
+
         static async upsertBlockProperty(block: BlockIdentity, key: string, value: any): Promise<void> {
             await getLogseqLock.acquireAsync();
-            try {await logseq.Editor.upsertBlockProperty(block, key, value);}
-            catch(e) { console.error(e); }
+            try { await logseq.Editor.upsertBlockProperty(block, key, value); }
+            catch (e) { console.error(e); }
             finally { getLogseqLock.release(); }
-        }    
+        }
+    }
+    export class Cache {
+        static clear(): void {
+            console.log("Cache Hit:" ,cacheHit);
+            cacheHit = 0;
+            cache.clear();
+        }
     }
 }

--- a/src/converter/getContentDirectDependencies.ts
+++ b/src/converter/getContentDirectDependencies.ts
@@ -1,17 +1,28 @@
-import { BlockUUID } from "@logseq/libs/dist/LSPlugin";
-import { LOGSEQ_BLOCK_REF_REGEXP, LOGSEQ_EMBDED_BLOCK_REGEXP } from "../constants";
+import { BlockPageName, BlockUUID, PageEntity } from "@logseq/libs/dist/LSPlugin";
+import { LOGSEQ_BLOCK_REF_REGEXP, LOGSEQ_EMBDED_BLOCK_REGEXP, LOGSEQ_EMBDED_PAGE_REGEXP } from "../constants";
 
-export default function getContentDirectDependencies(content: string, format: string = "markdown"): BlockUUID[] {
+export default function getContentDirectDependencies(content: string, format: string = "markdown"): (BlockUUID | PageEntityName)[] {
     if(content == null || content == undefined) return [];
-    let result: Set<BlockUUID> = new Set();
-    //Add group 1 of all matches of LOGSEQ_EMBDED_BLOCK_REGEXP to result
+    let blockDependency: Set<BlockUUID> = new Set();
+    let pageDependency: Set<PageEntityName> = new Set();
+    //  Add dependencies due to LOGSEQ_BLOCK_REF_REGEXP
     let match;
     while (match = LOGSEQ_EMBDED_BLOCK_REGEXP.exec(content)) {
-        result.add(match[1]);
+        blockDependency.add(match[1]);
     }
-    //Add group 1 of all matches of LOGSEQ_BLOCK_REF_REGEXP to result
+    // Add dependencies due to LOGSEQ_BLOCK_REF_REGEXP
     while (match = LOGSEQ_BLOCK_REF_REGEXP.exec(content)) {
-        result.add(match[1]);
+        blockDependency.add(match[1]);
     }
-    return [...result];
+    // Add dependencies due to LOGSEQ_EMBDED_PAGE_REGEXP
+    while (match = LOGSEQ_EMBDED_BLOCK_REGEXP.exec(content)) {
+        pageDependency.add(new PageEntityName(match[1]));
+    }
+    return [...blockDependency, ...pageDependency];
+}
+
+export class PageEntityName {
+    constructor(public name: string) {
+        this.name = name;
+    }
 }

--- a/src/converter/getContentDirectDependencies.ts
+++ b/src/converter/getContentDirectDependencies.ts
@@ -1,0 +1,17 @@
+import { BlockUUID } from "@logseq/libs/dist/LSPlugin";
+import { LOGSEQ_BLOCK_REF_REGEXP, LOGSEQ_EMBDED_BLOCK_REGEXP } from "../constants";
+
+export default function getContentDirectDependencies(content: string, format: string = "markdown"): BlockUUID[] {
+    if(content == null || content == undefined) return [];
+    let result: Set<BlockUUID> = new Set();
+    //Add group 1 of all matches of LOGSEQ_EMBDED_BLOCK_REGEXP to result
+    let match;
+    while (match = LOGSEQ_EMBDED_BLOCK_REGEXP.exec(content)) {
+        result.add(match[1]);
+    }
+    //Add group 1 of all matches of LOGSEQ_BLOCK_REF_REGEXP to result
+    while (match = LOGSEQ_BLOCK_REF_REGEXP.exec(content)) {
+        result.add(match[1]);
+    }
+    return [...result];
+}

--- a/src/notes/ClozeNote.ts
+++ b/src/notes/ClozeNote.ts
@@ -3,7 +3,6 @@ import '@logseq/libs'
 import { string_to_arr, get_math_inside_md, safeReplace } from '../utils';
 import _ from 'lodash';
 import { MD_PROPERTIES_REGEXP, ORG_PROPERTIES_REGEXP } from "../constants";
-import AwaitLock from 'await-lock';
 import { SyncronizedLogseq } from "../SyncronizedLogseq";
 
 export class ClozeNote extends Note {
@@ -82,14 +81,14 @@ export class ClozeNote extends Note {
           [?b :block/properties ?p]
           [(get ?p :replacecloze)]
         ]`);
-        let logseqCloze_blocks = await logseq.DB.datascriptQuery(`
+        let logseqCloze_blocks = await SyncronizedLogseq.DB.datascriptQueryBlocks(`
         [:find (pull ?b [*])
         :where
         [?b :block/content ?content]
         [(re-pattern "{{cloze .*}}") ?regex]
         [(re-find ?regex ?content)]
         ]`);
-        let orgCloze_blocks = await logseq.DB.datascriptQuery(`
+        let orgCloze_blocks = await SyncronizedLogseq.DB.datascriptQueryBlocks(`
         [:find (pull ?b [*])
         :where
         [?b :block/content ?content]

--- a/src/notes/MultilineCardNote.ts
+++ b/src/notes/MultilineCardNote.ts
@@ -158,7 +158,6 @@ export class MultilineCardNote extends Note {
             }
             return result;
         }
-        console.log("getDirectDeendencies", [this.uuid,...getChildrenUUID(this.children)]);
         return [this.uuid,...getChildrenUUID(this.children)];
     }
 }

--- a/src/notes/MultilineCardNote.ts
+++ b/src/notes/MultilineCardNote.ts
@@ -54,18 +54,18 @@ export class MultilineCardNote extends Note {
         return maxDepth;
     }
 
-    public addClozes(): MultilineCardNote {
-        let result = this.content;
+    public async getClozedContentHTML(): Promise<HTMLFile> {
+        let clozedContent = this.content;
         let direction = this.getCardDirection();
 
         // Remove clozes and double braces one after another
-        result = result.replace(ANKI_CLOZE_REGEXP, "$3");
-        result = result.replace(/(?<!{{embed [^}\n]*?)}}/g, "} } ");
+        clozedContent = clozedContent.replace(ANKI_CLOZE_REGEXP, "$3");
+        clozedContent = clozedContent.replace(/(?<!{{embed [^}\n]*?)}}/g, "} } ");
         
         // Add cloze to the parent block if direction is <-> or <-
-        result = safeReplace(result, MD_PROPERTIES_REGEXP, "");
+        clozedContent = safeReplace(clozedContent, MD_PROPERTIES_REGEXP, "");
         if (direction == "<->" || direction == "<-")
-            result = `{{c2:: ${result} }}`;
+            clozedContent = `{{c2:: ${clozedContent} }}`;
 
         // Add the content of children blocks and cloze it if direction is <-> or ->
         let cloze_id = 1;
@@ -90,10 +90,9 @@ export class MultilineCardNote extends Note {
             result += `</ul>`;
             return result;
         }
-        result += addChildrenToResult(this.children);
+        clozedContent += addChildrenToResult(this.children);
         
-        this.content = result;
-        return this;
+        return convertToHTMLFile(clozedContent, this.format);
     }
 
     private static async augmentChildrenArray(children: any): Promise<any> {

--- a/src/notes/Note.ts
+++ b/src/notes/Note.ts
@@ -30,7 +30,7 @@ export abstract class Note {
         Note.ankiNoteManager = ankiNoteManager;
     }
 
-    public abstract addClozes(): Note;
+    public abstract getClozedContentHTML(): Promise<HTMLFile>;
 
     public getContent(): string {
         return this.content;
@@ -43,10 +43,6 @@ export abstract class Note {
         if(filteredankiNotesArr.length == 0) this.ankiId = null;
         else this.ankiId = parseInt(filteredankiNotesArr[0].noteId);
         return this.ankiId;
-    }
-
-    public async convertToHtmlFile(): Promise<HTMLFile> {
-        return await convertToHTMLFile(this.content, this.format);
     }
 
     public getDirectDeendencies(): BlockUUID[] {

--- a/src/notes/Note.ts
+++ b/src/notes/Note.ts
@@ -7,6 +7,7 @@ import getContentDirectDependencies, { PageEntityName } from '../converter/getCo
 import { SyncronizedLogseq } from '../SyncronizedLogseq';
 import objectHash from "object-hash";
 import pkg from '../../package.json';
+import hashSum from 'hash-sum';
 
 export abstract class Note {
     public uuid: string;
@@ -83,7 +84,7 @@ export abstract class Note {
         }
         toHash.push({page:encodeURIComponent(_.get(this, 'page.originalName', '')), deck:encodeURIComponent(_.get(this, 'page.properties.deck', ''))});
         toHash.push({v:pkg.version});
-        return objectHash(toHash);
+        return hashSum(toHash); // hashSum is faster than objectHash but collisions rate is high (here, it suits our case of detecting changes)
     }
 
     // public static async abstract getBlocksFromLogseq(): Block[];

--- a/src/syncLogseqToAnki.ts
+++ b/src/syncLogseqToAnki.ts
@@ -105,7 +105,7 @@ export class LogseqToAnkiSync {
         for (let note of toCreateNotes) {
             try {
                 let [html, assets, deck, breadcrumb, tags, extra] = await this.parseNote(note);
-                let dependencyHash = await note.getAllDependenciesHash([html, Array.from(assets), breadcrumb, tags, extra])
+                let dependencyHash = await note.getAllDependenciesHash([html, Array.from(assets), deck, breadcrumb, tags, extra])
                 // Add assets
                 const graphPath = (await logseq.App.getCurrentGraph()).path;
                 assets.forEach(asset => {
@@ -155,12 +155,12 @@ export class LogseqToAnkiSync {
                     try { return JSON.parse(configString); }
                     catch (e) { return {}; }
                 })(ankiNodeInfo.fields.Config.value);
-                let [oldHtml, oldAssets, oldBreadcrumb, oldTags, oldExtra] = [ankiNodeInfo.fields.Text.value, oldConfig.assets, ankiNodeInfo.fields.Breadcrumb.value, ankiNodeInfo.tags, ankiNodeInfo.fields.Extra.value];
-                let dependencyHash = await note.getAllDependenciesHash([oldHtml, oldAssets, oldBreadcrumb, oldTags, oldExtra]);
+                let [oldHtml, oldAssets, oldDeck, oldBreadcrumb, oldTags, oldExtra] = [ankiNodeInfo.fields.Text.value, oldConfig.assets, ankiNodeInfo.deck, ankiNodeInfo.fields.Breadcrumb.value, ankiNodeInfo.tags, ankiNodeInfo.fields.Extra.value];
+                let dependencyHash = await note.getAllDependenciesHash([oldHtml, oldAssets, oldDeck, oldBreadcrumb, oldTags, oldExtra]);
                 if(oldConfig.dependencyHash != dependencyHash || logseq.settings.ignoreDependencyHash) { // Reparse Note + update assets + update
                     // Parse Note
                     let [html, assets, deck, breadcrumb, tags, extra] = await this.parseNote(note);
-                    dependencyHash = await note.getAllDependenciesHash([html, Array.from(assets), breadcrumb, tags, extra]);
+                    dependencyHash = await note.getAllDependenciesHash([html, Array.from(assets), deck, breadcrumb, tags, extra]);
                     // Add or update assets
                     const graphPath = (await logseq.App.getCurrentGraph()).path;
                     assets.forEach(asset => {

--- a/src/syncLogseqToAnki.ts
+++ b/src/syncLogseqToAnki.ts
@@ -81,6 +81,7 @@ export class LogseqToAnkiSync {
         await this.updateNotes(toUpdateNotes, failedUpdated, ankiNoteManager);
         await this.deleteNotes(toDeleteNotes, ankiNoteManager, failedDeleted);
         await AnkiConnect.invoke("reloadCollection", {});
+        SyncronizedLogseq.Cache.clear();
 
         // -- Show Result / Summery --
         let summery = `Sync Completed! \n Created Blocks: ${toCreateNotes.length - failedCreated.size} \n Updated Blocks: ${toUpdateNotes.length - failedUpdated.size} \n Deleted Blocks: ${toDeleteNotes.length - failedDeleted.size}`;

--- a/src/syncLogseqToAnki.ts
+++ b/src/syncLogseqToAnki.ts
@@ -219,7 +219,9 @@ export class LogseqToAnkiSync {
                 parentID = parent.parent.id;
             }
             for await (const parentBlock of parentBlocks.reverse()) {
-                newHtml += `<ul class="children-list"><li class="children">${(await convertToHTMLFile(parentBlock.content, parentBlock.format)).html}`;
+                let parentBlockConverted = await convertToHTMLFile(parentBlock.content, parentBlock.format);
+                parentBlockConverted.assets.forEach(asset => assets.add(asset));
+                newHtml += `<ul class="children-list"><li class="children">${parentBlockConverted.html}`;
             };
             newHtml += `<ul class="children-list"><li class="children">${html}</li></ul>`;
             parentBlocks.reverse().forEach(parentBlock => {

--- a/src/syncLogseqToAnki.ts
+++ b/src/syncLogseqToAnki.ts
@@ -167,7 +167,7 @@ export class LogseqToAnkiSync {
                         ankiNoteManager.storeAsset(encodeURIComponent(asset), path.join(graphPath, path.resolve(asset)))
                     });
                     // Update note
-                    console.log("Not skipping update of note", note.uuid, note.type);
+                    if(logseq.settings.syncDebug) console.log("Not skipping update of note", note.uuid);
                     ankiNoteManager.updateNote(ankiId, deck, this.modelName, { "uuid-type": `${note.uuid}-${note.type}`, "uuid": note.uuid, "Text": html, "Extra": extra, "Breadcrumb": breadcrumb, "Config": JSON.stringify({dependencyHash,assets:[...assets]}) }, tags);
                 } else { // Just update old assets
                     const graphPath = (await logseq.App.getCurrentGraph()).path;

--- a/src/syncLogseqToAnki.ts
+++ b/src/syncLogseqToAnki.ts
@@ -105,13 +105,14 @@ export class LogseqToAnkiSync {
         for (let note of toCreateNotes) {
             try {
                 let [html, assets, deck, breadcrumb, tags, extra] = await this.parseNote(note);
+                let dependencyHash = await note.getAllDependenciesHash([html, Array.from(assets), breadcrumb, extra]);;
                 // Add assets
                 const graphPath = (await logseq.App.getCurrentGraph()).path;
                 assets.forEach(asset => {
                     ankiNoteManager.storeAsset(encodeURIComponent(asset), path.join(graphPath, path.resolve(asset)))
                 });
                 // Create note
-                ankiNoteManager.addNote(deck, this.modelName, { "uuid-type": `${note.uuid}-${note.type}`, "uuid": note.uuid, "Text": html, "Extra": extra, "Breadcrumb": breadcrumb, "Config": JSON.stringify({dependencyHash:await note.getAllDependenciesHash(),assets:[...assets]}) }, tags);
+                ankiNoteManager.addNote(deck, this.modelName, { "uuid-type": `${note.uuid}-${note.type}`, "uuid": note.uuid, "Text": html, "Extra": extra, "Breadcrumb": breadcrumb, "Config": JSON.stringify({dependencyHash,assets:[...assets]}) }, tags);
             } catch (e) {
                 console.error(e); failedCreated.add(`${note.uuid}-${note.type}`);
             }

--- a/src/syncLogseqToAnki.ts
+++ b/src/syncLogseqToAnki.ts
@@ -207,7 +207,7 @@ export class LogseqToAnkiSync {
     }
 
     private async parseNote(note: Note): Promise<[string, Set<string>, string, string, string[], string]> {
-        let {html, assets} = await note.addClozes().convertToHtmlFile();
+        let {html, assets} = await note.getClozedContentHTML();
         
         if(logseq.settings.includeParentContent) {
             let newHtml = "";

--- a/src/syncLogseqToAnki.ts
+++ b/src/syncLogseqToAnki.ts
@@ -105,7 +105,7 @@ export class LogseqToAnkiSync {
         for (let note of toCreateNotes) {
             try {
                 let [html, assets, deck, breadcrumb, tags, extra] = await this.parseNote(note);
-                let dependencyHash = await note.getAllDependenciesHash([html, Array.from(assets), breadcrumb, extra]);;
+                let dependencyHash = await note.getAllDependenciesHash([html, Array.from(assets), breadcrumb, tags, extra])
                 // Add assets
                 const graphPath = (await logseq.App.getCurrentGraph()).path;
                 assets.forEach(asset => {
@@ -155,12 +155,12 @@ export class LogseqToAnkiSync {
                     try { return JSON.parse(configString); }
                     catch (e) { return {}; }
                 })(ankiNodeInfo.fields.Config.value);
-                let [oldHtml, oldAssets, oldBreadcrumb, oldExtra] = [ankiNodeInfo.fields.Text.value, oldConfig.assets, ankiNodeInfo.fields.Breadcrumb.value, ankiNodeInfo.fields.Extra.value];
-                let dependencyHash = await note.getAllDependenciesHash([oldHtml, oldAssets, oldBreadcrumb, oldExtra]);
+                let [oldHtml, oldAssets, oldBreadcrumb, oldTags, oldExtra] = [ankiNodeInfo.fields.Text.value, oldConfig.assets, ankiNodeInfo.fields.Breadcrumb.value, ankiNodeInfo.tags, ankiNodeInfo.fields.Extra.value];
+                let dependencyHash = await note.getAllDependenciesHash([oldHtml, oldAssets, oldBreadcrumb, oldTags, oldExtra]);
                 if(oldConfig.dependencyHash != dependencyHash || logseq.settings.ignoreDependencyHash) { // Reparse Note + update assets + update
                     // Parse Note
                     let [html, assets, deck, breadcrumb, tags, extra] = await this.parseNote(note);
-                    dependencyHash = await note.getAllDependenciesHash([html, Array.from(assets), breadcrumb, extra]);
+                    dependencyHash = await note.getAllDependenciesHash([html, Array.from(assets), breadcrumb, tags, extra]);
                     // Add or update assets
                     const graphPath = (await logseq.App.getCurrentGraph()).path;
                     assets.forEach(asset => {

--- a/src/syncLogseqToAnki.ts
+++ b/src/syncLogseqToAnki.ts
@@ -111,7 +111,7 @@ export class LogseqToAnkiSync {
                     ankiNoteManager.storeAsset(encodeURIComponent(asset), path.join(graphPath, path.resolve(asset)))
                 });
                 // Create note
-                ankiNoteManager.addNote(deck, this.modelName, { "uuid-type": `${note.uuid}-${note.type}`, "uuid": note.uuid, "Text": html, "Extra": extra, "Breadcrumb": breadcrumb }, tags);
+                ankiNoteManager.addNote(deck, this.modelName, { "uuid-type": `${note.uuid}-${note.type}`, "uuid": note.uuid, "Text": html, "Extra": extra, "Breadcrumb": breadcrumb, "Config": JSON.stringify({dependencyHash:await note.getAllDependenciesHash(),assets:[...assets]}) }, tags);
             } catch (e) {
                 console.error(e); failedCreated.add(`${note.uuid}-${note.type}`);
             }


### PR DESCRIPTION
Introduces dependency hash. It is a hash stored in anki which when matched with current note's hash will prevent updation + rendering. Essentially, it improves lazy updation greatly.
Dependency hash is made up of: Logseq Block & Page Contents (+ contents of it's references), Current Plugin Version, Current Anki Card Content etc. It can be used to detect whenever any of those change and update accordingly.


**Statistics:**
--300 notes--
Initial Sync Time: 15 secs 
Update Sync Time: 2 secs
--2000 notes--
Initial Sync Time: 70 secs
Update Sync Time: 20 secs

**Status:**
- [x] Implementation
- [ ] Testing
