### PR TITLE
feat: add namespace processing logic

### DIFF
--- a/src/notes/Note.ts
+++ b/src/notes/Note.ts
@@ -13,6 +13,8 @@ export abstract class Note {
     public type: string;
     public ankiId: number;
     static ankiNoteManager: LazyAnkiNoteManager;
+    public parseNamespace:boolean;
+
 
     public constructor(uuid: string, content: string, format: string, properties: any, page: any) {
         this.uuid = uuid;
@@ -21,6 +23,7 @@ export abstract class Note {
         this.properties = properties;
         this.page = page;
         this.page.originalName = _.get(this, 'page.originalName', null) || _.get(this, 'page.name', null); // Just in case the page doesn't have an originalName
+        this.parseNamespace = false;
     }
 
     public static setAnkiNoteManager(ankiNoteManager: LazyAnkiNoteManager) {

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -29,6 +29,13 @@ export const addSettingsToLogseq = () => {
             description: "Include parent content in cards. When enabled, the parent content will be included in the card.",
         },
         {
+            key: "deckFromLogseqNamespace",
+            type: 'boolean',
+            default: true,
+            title: "Create namespace in anki (Default: Enabled)",
+            description: "You can turn this off to avoid journal like \"yyyy/MM/dd\" being processed as nested decks, but the namespace will still be parsed when the root page has the property parsens is true.",
+        },
+        {
             key: "defaultDeck",
             type: 'string',
             title: "Default Deck:",


### PR DESCRIPTION
Did a lot of trivial work.

1.When the option is on, namespace are parsed permanently.
2.When the option is off and the root page has the property parsens is true, the namespace will still be parsed and will update on next sync.

Hope to merge.