### PR TITLE
enhance: add "On hover" style for rendering broken cloze macro

### DIFF
--- a/src/notes/ClozeNote.ts
+++ b/src/notes/ClozeNote.ts
@@ -32,6 +32,27 @@ export class ClozeNote extends Note {
             ["editor/input", `replacecloze:: " '' "`, { "backward-pos": 3 }],
             ["editor/clear-current-slash"],
         ]);
+        
+        if (logseq.settings.renderAnkiClozeMarcosInLogseq.includes("On hover")) {
+            logseq.provideStyle(`
+                .anki-cloze {
+                    color: transparent !important;
+                    background: unset !important;
+                    text-decoration: underline 1px dashed var(--ls-primary-text-color) !important;
+                    text-underline-position: under !important;
+                    }
+                    .anki-cloze:hover {
+                    color: var(--ls-primary-text-color) !important;
+                    background: unset !important;
+                }
+            `);
+        } else if (logseq.settings.renderAnkiClozeMarcosInLogseq == "On") {
+            logseq.provideStyle(`
+                .anki-cloze {
+                    background-color:rgb(59 130 246 / 0.1);
+                }
+            `);
+        }
         const setupAnkiClozeObserverAndRenderThemInLogseqWhenObserved = () => {
             // Set up observer for Anki Cloze Macro Syntax
             const displayAnkiCloze = (elem: Element) => {
@@ -48,14 +69,11 @@ export class ClozeNote extends Note {
                             /^{?{{c\d (.*?)((::|\\\\).*)?}}}?$/,
                             "$1",
                         );
-                        if (logseq.settings.renderAnkiClozeMarcosInLogseq)
-                            content = (
-                                await convertToHTMLFile(content, "markdown")
-                            ).html;
+                        content = ( await convertToHTMLFile(content, "markdown") ).html;
                         // if parent element has class macro
                         if (cloze.parentElement.classList.contains("macro"))
                             cloze.parentElement.style.display = "initial";
-                        cloze.outerHTML = `<span style="background-color:rgb(59 130 246 / 0.1);white-space: initial;">${content}</span>`;
+                        cloze.outerHTML = `<span class="anki-cloze" style="white-space: initial;">${content}</span>`;
                     }
                 });
             };
@@ -74,6 +92,7 @@ export class ClozeNote extends Note {
                 childList: true,
             });
         };
+        if (logseq.settings.renderAnkiClozeMarcosInLogseq != "Off")
         setupAnkiClozeObserverAndRenderThemInLogseqWhenObserved();
     };
 

--- a/src/notes/ClozeNote.ts
+++ b/src/notes/ClozeNote.ts
@@ -33,7 +33,7 @@ export class ClozeNote extends Note {
             ["editor/clear-current-slash"],
         ]);
         
-        if (logseq.settings.renderAnkiClozeMarcosInLogseq.includes("On hover")) {
+        if (logseq.settings.showClozesOnHoverInAnki) {
             logseq.provideStyle(`
                 .anki-cloze {
                     color: transparent !important;
@@ -46,7 +46,8 @@ export class ClozeNote extends Note {
                     background: unset !important;
                 }
             `);
-        } else if (logseq.settings.renderAnkiClozeMarcosInLogseq == "On") {
+        } 
+        if (logseq.settings.renderAnkiClozeMarcosInLogseq) {
             logseq.provideStyle(`
                 .anki-cloze {
                     background-color:rgb(59 130 246 / 0.1);
@@ -69,7 +70,10 @@ export class ClozeNote extends Note {
                             /^{?{{c\d (.*?)((::|\\\\).*)?}}}?$/,
                             "$1",
                         );
-                        content = ( await convertToHTMLFile(content, "markdown") ).html;
+                        if (logseq.settings.renderAnkiClozeMarcosInLogseq)
+                            content = (
+                                await convertToHTMLFile(content, "markdown")
+                            ).html;
                         // if parent element has class macro
                         if (cloze.parentElement.classList.contains("macro"))
                             cloze.parentElement.style.display = "initial";
@@ -92,7 +96,7 @@ export class ClozeNote extends Note {
                 childList: true,
             });
         };
-        if (logseq.settings.renderAnkiClozeMarcosInLogseq != "Off")
+        if (logseq.settings.renderAnkiClozeMarcosInLogseq || logseq.settings.showClozesOnHoverInAnki)
         setupAnkiClozeObserverAndRenderThemInLogseqWhenObserved();
     };
 

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -76,11 +76,17 @@ export const addSettingsToLogseq = () => {
         },
         {
             key: "renderAnkiClozeMarcosInLogseq",
-            type: "boolean",
-            default: false,
-            title: "Render Anki Cloze Macros in Logseq? (Recommended: Disabled) [Experimental] [In Development]",
+            type: "enum",
+            default: "",
+            title: "Render Anki Cloze Macros by plugin in Logseq? (Recommended: Off) [Experimental] [In Development]",
             description:
-                "Render Anki Cloze Macros in Logseq. <br/> When enabled, the Anki Cloze Macros ({{c1 Pikachu}}, {{c2 Mew}}, ...) will be rendered in Logseq.",
+                "When enabled, the Anki Cloze Macros ({{c1 Pikachu}}, {{c2 Mew}}, ...) will be rendered as normal text or blanks that turn visible on hover. Refresh or reopen Logseq to take effect.",
+            enumChoices: [
+                "Off",
+                "On",
+                "On hover",
+            ],
+            enumPicker: "select",
         },
         {
             key: "advancedSettingsHeading",

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -76,17 +76,19 @@ export const addSettingsToLogseq = () => {
         },
         {
             key: "renderAnkiClozeMarcosInLogseq",
-            type: "enum",
-            default: "",
-            title: "Render Anki Cloze Macros by plugin in Logseq? (Recommended: Off) [Experimental] [In Development]",
+            type: "boolean",
+            default: false,
+            title: "Render Anki Cloze Macros in Logseq? (Recommended: Disabled) [Experimental] [In Development]",
             description:
-                "When enabled, the Anki Cloze Macros ({{c1 Pikachu}}, {{c2 Mew}}, ...) will be rendered as normal text or blanks that turn visible on hover. Refresh or reopen Logseq to take effect.",
-            enumChoices: [
-                "Off",
-                "On",
-                "On hover",
-            ],
-            enumPicker: "select",
+                "Render Anki Cloze Macros in Logseq. <br/> When enabled, the Anki Cloze Macros ({{c1 Pikachu}}, {{c2 Mew}}, ...) will be rendered in Logseq.",
+        },
+        {
+            key: "showClozesOnHoverInAnki",
+            type: "boolean",
+            default: false,
+            title: "Display Anki Cloze content on mouse hover? (Recommended: Disabled) [Experimental] [In Development]",
+            description:
+                "When enabled, the content in Anki Cloze Macros ({{c1 Pikachu}}, {{c2 Mew}}, ...) will be blank visible only in mouse hover mode.",
         },
         {
             key: "advancedSettingsHeading",


### PR DESCRIPTION

![on hover](https://github.com/debanjandhar12/logseq-anki-sync/assets/37920155/6e2a5ee2-95fd-48ff-8314-85addd2ec2df)

Hi! Inspired by another plugin `logseq-plugin-wrap` , this PR 
- adds "On hover" style for rendering cloze (as shown in the gif)
- updates menu for the change