### PR TITLE
enhance: specify cloze number by {{clozeID xxx}}

### DIFF
--- a/src/notes/ClozeNote.ts
+++ b/src/notes/ClozeNote.ts
@@ -179,13 +179,18 @@ export class ClozeNote extends Note {
         }
 
         // --- Add logseq clozes ---
-        clozedContent = safeReplace(clozedContent, /\{\{cloze (.*?)\}\}/g, (match, group1) => {
-            group1 = group1.replace(
-                /(.*)(\\\\|::)(.*)/,
-                (match, g1, g2, g3) => `${g1.trim()}::${g3.trim()}`,
-            ); // Add support for logseq cloze cue
-            return `{{c${cloze_id++}::${group1}}}`;
-        });
+        clozedContent = safeReplace(
+            clozedContent,
+            /\{\{cloze(\d{1,})? (.*?)\}\}/g,
+            (match, group1, group2) => {
+                group2 = group2.replace(
+                    /(.*)(\\\\|::)(.*)/,
+                    (match, g1, g2, g3) => `${g1.trim()}::${g3.trim()}`,
+                ); // Add support for logseq cloze cue
+                if (group1) return `{{c${group1}::${group2}}}`;
+                return `{{c${cloze_id++}::${group1}}}`;
+            },
+        );
 
         // --- Add org block clozes ---
         clozedContent = safeReplace(

--- a/src/notes/ClozeNote.ts
+++ b/src/notes/ClozeNote.ts
@@ -209,11 +209,13 @@ export class ClozeNote extends Note {
 
     public static async getNotesFromLogseqBlocks(): Promise<ClozeNote[]> {
         // Get blocks with Anki or Logseq cloze macro syntax
+        const clozeRegex = /{{(c\d*|cloze\d*) .*}}/;
+        const clozePattern = clozeRegex.source.replace(/\\/g, "\\\\");
         const macroCloze_blocks = await LogseqProxy.DB.datascriptQuery(`
         [:find (pull ?b [*])
         :where
         [?b :block/content ?content]
-        [(re-pattern "{{(c[0-9]|cloze) .*}}") ?regex]
+        [(re-pattern "${clozePattern}") ?regex]
         [(re-find ?regex ?content)]
         ]`);
         // Get blocks with .replacecloze or replacecloze property

--- a/src/notes/ClozeNote.ts
+++ b/src/notes/ClozeNote.ts
@@ -63,9 +63,9 @@ export class ClozeNote extends Note {
                 if (!clozes) return;
                 clozes = elem.querySelectorAll('span[title^="Unsupported macro name: c"]');
                 clozes.forEach(async (cloze) => {
-                    if (/c\d$/.test((cloze as Element & {title}).title)) {
+                    if (/c(loze)?\d$/.test((cloze as Element & { title }).title)) {
                         let content = cloze.innerHTML.replace(
-                            /^{?{{c\d (.*?)((::|\\\\).*)?}}}?$/,
+                            /^{?{{c(?:loze)?\d (.*?)((::|\\\\).*)?}}}?$/,
                             "$1",
                         );
                         if (logseq.settings.renderClozeMarcosInLogseq)
@@ -188,7 +188,7 @@ export class ClozeNote extends Note {
                     (match, g1, g2, g3) => `${g1.trim()}::${g3.trim()}`,
                 ); // Add support for logseq cloze cue
                 if (group1) return `{{c${group1}::${group2}}}`;
-                return `{{c${cloze_id++}::${group1}}}`;
+                return `{{c${cloze_id++}::${group2}}}`;
             },
         );
 


### PR DESCRIPTION
This PR enables cloze syntax like `{{cloze1 xxx}}`, where the number after keyword `cloze` specifies the display order of the cloze. 
It works the same as `{{c1 xxx}}`. 

Motivation: In logseq, the keyword for cloze macro is `cloze`, instead of `c` in anki style. So maybe it's reasonable to support also parsing `clozeID` syntax. For example, when one wants to force `{{cloze a}}` to appear in the 2nd card, there would be a slight advantage in modifying it to `{{cloze2 a}}` over `{{c2 a}}`.