### PR TITLE
Fix bug jkl don't move to correct bullet

### DIFF
--- a/src/templates/template.html
+++ b/src/templates/template.html
@@ -5,6 +5,8 @@
     var type = "";
     var style, load_event;
     var process = {'env': { 'NODE_DEBUG': false }}; // required for difflib to work correctly
+    var keydownHandler;
+
 </script>
 <script async="false" defer="false">
     try {
@@ -32,17 +34,24 @@
     document.body.appendChild(style);
 </script>
 <script async="false" defer="false">
-    document.addEventListener('keydown', function(event) {
+    if (keydownHandler) {
+        document.removeEventListener('keydown', keydownHandler, true);
+    }
+    function keydownMethod(event) {
         if (event.shiftKey) {
             if (event.keyCode === 74) {
                 scrollToClozeElement();
             } else if (event.keyCode === 75) {
+                console.log('event in method : ', '{{uuid}}');
                 openBlockInLogseq('{{uuid}}');
             } else if (event.keyCode === 76) {
                 window.scroll(0, 0);
             }
         }
-    })
+    }
+    keydownHandler = keydownMethod;
+    console.log('addEventListener evoke');
+    document.addEventListener('keydown', keydownHandler, true);
 </script>
 <div style="display: flex; justify-content: space-between" role="menubar">
     <div class="bubble breadcrumb2">{{Breadcrumb}}</div>

--- a/src/templates/template.html
+++ b/src/templates/template.html
@@ -49,7 +49,6 @@
         }
     }
     keydownHandler = keydownMethod;
-    console.log('addEventListener evoke');
     document.addEventListener('keydown', keydownHandler, true);
 </script>
 <div style="display: flex; justify-content: space-between" role="menubar">

--- a/src/templates/template.html
+++ b/src/templates/template.html
@@ -42,7 +42,6 @@
             if (event.keyCode === 74) {
                 scrollToClozeElement();
             } else if (event.keyCode === 75) {
-                console.log('event in method : ', '{{uuid}}');
                 openBlockInLogseq('{{uuid}}');
             } else if (event.keyCode === 76) {
                 window.scroll(0, 0);


### PR DESCRIPTION
First card, JKL is ok in anki.

After cards have problem because document have before JKL keydown events.
So shift + K button(move to loseq bullet) is not work I expected.

So I delete eventListener before add new EventListener.
