### PR TITLE
Fix '::' breaking code block rendering.

### DIFF
--- a/src/logseq/LogseqToHtmlConverter.ts
+++ b/src/logseq/LogseqToHtmlConverter.ts
@@ -225,9 +225,9 @@ export async function convertToHTMLFile(
                 $(elm).html(
                     hljs
                         .highlight(elm.attribs["data-lang"], $(elm).text())
-                        .value.replace(/\n$/, ""),
+                        .value.replace(/\n$/, "").replace(/::/g, '<span>&#58;</span><span>&#58;</span>'),
                 );
-            } else $(elm).html(hljs.highlightAuto($(elm).html()).value.replace(/\n$/, ""));
+            } else $(elm).html(hljs.highlightAuto($(elm).html()).value.replace(/\n$/, "").replace(/::/g, '<span>&#58;</span><span>&#58;</span>'));
         } catch (e) {
             console.warn(e);
         }


### PR DESCRIPTION
Replaces `::` in code blocks with `<span>&#58;</span><span>&#58;</span>` in the html

This is a hotfix for the following issues:
#206 
#296

Since the use of double colons break code block rendering I thought it was being parsed as a page property, but when adding console log statements to  [processProperties()](https://github.com/debanjandhar12/logseq-anki-sync/blob/04b2503a1a1632a6727877fbdcda27acb1ae5814/src/logseq/LogseqToHtmlConverter.ts#L307) it didn't show them. Would have expected std::cout to be a key value pair if it was. 

Not sure what the real culprit is, but I think it is one of the regex statements.