### PR TITLE
enhance the way breadcrumb page titles are retrieved

### DIFF
--- a/src/syncLogseqToAnki.ts
+++ b/src/syncLogseqToAnki.ts
@@ -699,7 +699,6 @@ export class LogseqToAnkiSync {
         );
         assets = new Set([...assets, ...extra.assets]);
         extra = extra.html;
-        console.log(breadcrumb);
         return [html, assets, deck, breadcrumb, tags, extra];
     }
 }

--- a/src/syncLogseqToAnki.ts
+++ b/src/syncLogseqToAnki.ts
@@ -499,6 +499,16 @@ export class LogseqToAnkiSync {
         }
     }
 
+
+    private getBreadcrumbName = (page) => {
+        return page.properties?.title ||           // Frontmatter title
+                page.properties?.alias ||           // Frontmatter alias  
+                page.title ||                       // Page title property
+                page.name ||                        // Clean page name
+                page.originalName ||                // Last resort
+                'Untitled'
+    }
+
     private async parseNote(
         note: Note,
     ): Promise<[string, Set<string>, string, string, string[], string]> {
@@ -611,14 +621,14 @@ export class LogseqToAnkiSync {
         let breadcrumb = `<a href="logseq://graph/${encodeURIComponent(
             this.graphName,
         )}?page=${encodeURIComponent(note.page.originalName)}" class="hidden">${
-            note.page.originalName
+            this.getBreadcrumbName(note.page)
         }</a>`;
         if (logseq.settings.breadcrumbDisplay.includes("Show Page name"))
             breadcrumb = `<a href="logseq://graph/${encodeURIComponent(
                 this.graphName,
             )}?page=${encodeURIComponent(note.page.originalName)}" title="${
-                note.page.originalName
-            }">${note.page.originalName}</a>`;
+                this.getBreadcrumbName(note.page)
+            }">${this.getBreadcrumbName(note.page)}</a>`;
         if (logseq.settings.breadcrumbDisplay == "Show Page name and parent blocks context") {
             try {
                 const parentBlocks = [];
@@ -689,7 +699,7 @@ export class LogseqToAnkiSync {
         );
         assets = new Set([...assets, ...extra.assets]);
         extra = extra.html;
-
+        console.log(breadcrumb);
         return [html, assets, deck, breadcrumb, tags, extra];
     }
 }


### PR DESCRIPTION
This will allow users to specify a friendly name for the breadcrumb. In my case, breadcrumbs for PDF annotation pages were really ugly due to the pdf id being part of the `originalName` property that was used previously.