### PR TITLE
Feat: Implement missing User Controlled Fields featureUser controlled field

### DIFF
--- a/src/anki-connect/AnkiConnect.ts
+++ b/src/anki-connect/AnkiConnect.ts
@@ -159,6 +159,18 @@ export async function createModel(
             ],
         });
         console.log(`Created new model ${modelName}`);
+    } else {
+        // Check for missing fields and add them
+        const existingFields = await invoke("modelFieldNames", {modelName: modelName});
+        const missingFields = _.difference(fields, existingFields);
+        for (const field of missingFields) {
+            console.log(`Adding missing field ${field} to model ${modelName}`);
+            await invoke("modelFieldAdd", {
+                modelName: modelName,
+                fieldName: field,
+                index: fields.indexOf(field)
+            });
+        }
     }
 
     try {

--- a/src/anki-connect/LazyAnkiNoteManager.ts
+++ b/src/anki-connect/LazyAnkiNoteManager.ts
@@ -148,6 +148,12 @@ export class LazyAnkiNoteManager {
             }
         }
         if (needsFieldUpdate) {
+            // Delete user controlled fields from fields object to avoid overwriting them
+            const fieldsToUpdate = {...fields};
+            delete fieldsToUpdate["User Controlled Field (Front)"];
+            delete fieldsToUpdate["User Controlled Field (Back)"];
+            delete fieldsToUpdate["User Controlled Field (Both)"];
+
             this.updateNoteActionsQueue.push({
                 action: "updateNoteFields",
                 params: {
@@ -155,7 +161,7 @@ export class LazyAnkiNoteManager {
                         id: ankiId,
                         deckName: deckName,
                         modelName: modelName,
-                        fields: fields,
+                        fields: fieldsToUpdate,
                     },
                 },
             });

--- a/src/syncLogseqToAnki.ts
+++ b/src/syncLogseqToAnki.ts
@@ -76,7 +76,7 @@ export class LogseqToAnkiSync {
         // -- Create models if it doesn't exists --
         await AnkiConnect.createModel(
             this.modelName,
-            ["uuid-type", "uuid", "Text", "Extra", "Breadcrumb", "Config"],
+            ["uuid-type", "uuid", "Text", "Extra", "Breadcrumb", "Config", "User Controlled Field (Front)", "User Controlled Field (Back)", "User Controlled Field (Both)"],
             getTemplateFront(),
             getTemplateBack(),
             getTemplateMediaFiles()
@@ -327,6 +327,9 @@ export class LogseqToAnkiSync {
                             dependencyHash,
                             assets: [...assets],
                         }),
+                        "User Controlled Field (Front)": "",
+                        "User Controlled Field (Back)": "",
+                        "User Controlled Field (Both)": "",
                     },
                     tags,
                 );

--- a/src/templates/_logseq_anki_sync.scss
+++ b/src/templates/_logseq_anki_sync.scss
@@ -501,6 +501,32 @@ body.nightMode div.warning::before {
     border-color: #bfbfbf;
 }
 
+/* --- User Controlled Fields --- */
+.user-controlled-fields {
+    margin-top: 10px;
+    font-size: 0.9em;
+    font-style: italic;
+    color: #666;
+}
+
+body.nightMode .user-controlled-fields {
+    color: #999;
+}
+
+/* Hide front-only fields on back side and vice-versa */
+body:has(.anki-card-back-side) .user-field-front {
+    display: none;
+}
+
+body:has(.anki-card-front-side) .user-field-back {
+    display: none;
+}
+
+.user-field-front:empty, .user-field-back:empty, .user-field-both:empty {
+    display: none;
+}
+
+
 body.nightMode .embed-page,
 body.nightMode .embed-block {
     border: 2px solid #bfbfbf;

--- a/src/templates/template.html
+++ b/src/templates/template.html
@@ -77,6 +77,11 @@
         <input type="text" id="typeans" class="typePrompt" style="font-family: 'Arial'; font-size: 20px;" />
     </span>
     <div class="extra">{{Extra}}</div>
+    <div class="user-controlled-fields">
+        <div class="user-field-front">{{User Controlled Field (Front)}}</div>
+        <div class="user-field-back">{{User Controlled Field (Back)}}</div>
+        <div class="user-field-both">{{User Controlled Field (Both)}}</div>
+    </div>
 </span>
 <div id="additionalData" class="hidden">
     <div id="deck" deck_name="{{Deck}}"></div>


### PR DESCRIPTION


### **Description**
I noticed that the [Sync Behavior documentation](https://debanjandhar12.github.io/logseq-anki-sync/docs/advanced/sync-behavior) mentions "User Controlled Fields" as a way to protect custom content in Anki from being overwritten during sync. However, this feature was actually missing from the current codebase.

This PR implements the "User Controlled Fields" feature to align the code with the existing documentation.

### **Key Changes**
1. **Model Expansion**: Added three new fields to the Anki note model:
   - `User Controlled Field (Front)`
   - `User Controlled Field (Back)`
   - `User Controlled Field (Both)`
2. **Template Updates**: 
   - Modified `template.html` to include these fields.
   - Updated `_logseq_anki_sync.scss` with CSS logic to ensure `Front` fields only show on the front side and `Back` fields only show on the back side.
3. **One-Way Protection Logic**: 
   - Updated `LazyAnkiNoteManager.ts` to initialize these fields as empty strings when creating new notes.
   - Modified the update logic to explicitly exclude these fields during sync updates. This ensures that any manual changes made to these fields within Anki are preserved and never overwritten by Logseq.