### PR TITLE
fix: resolve assets:// URL before fetch in Flatpak environment

### DIFF
--- a/src/anki-connect/operations/AssetOperation.ts
+++ b/src/anki-connect/operations/AssetOperation.ts
@@ -92,7 +92,8 @@ export class AssetOperation {
 
     private async getBase64FromUrl(url: string): Promise<string> {
         try {
-            const response = await WindowParentBridge.getFetch()(url);
+            const resolvedUrl = await WindowParentBridge.makeAssetUrl(url);
+            const response = await WindowParentBridge.getFetch()(resolvedUrl);
             const blob = await response.blob();
             const reader = new FileReader();
             await new Promise((resolve, reject) => {


### PR DESCRIPTION
## Problem

When both Logseq and Anki are installed as Flatpak apps, images and image occlusions fail to sync to Anki's `collection.media`. The browser console shows:

```
Fetch API cannot load assets:////home/user/.../logseq/assets/image.png
URL scheme "assets" is not supported.
```

The `assets://` scheme is only valid within a native Electron context. In the Flatpak sandbox, `fetch()` cannot resolve it, causing `getBase64FromUrl` to silently fail and return an empty string. As a result:

- Images pasted into Logseq blocks are never copied to `collection.media`
- The image occlusion editor shows a blank image (the source PNG cannot be loaded)
- SVG occlusion masks are never generated

This affects both image sync and image occlusion on any Linux system running Logseq as a Flatpak.

## Fix

`WindowParentBridge.makeAssetUrl()` already exists and correctly resolves `assets://` paths to accessible URLs via `logseq.Assets.makeUrl()`. The fix simply calls it before passing the URL to `fetch()`:

```typescript
// Before
const response = await WindowParentBridge.getFetch()(url);

// After
const resolvedUrl = await WindowParentBridge.makeAssetUrl(url);
const response = await WindowParentBridge.getFetch()(resolvedUrl);
```

## Testing

Tested on:
- Fedora 42, GNOME/Wayland
- Logseq 0.10.15 (Flatpak, system install)
- Anki 25.09.04 (Flatpak, system install)

After the fix:
- Images pasted into Logseq blocks sync correctly to Anki
- Image occlusion editor loads images correctly
- SVG masks are generated and synced to Anki